### PR TITLE
ページを日本語で記述するための些細な更新

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-US" }}">
+<html lang="{{ site.lang | default: "ja-JP" }}">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="utf-8">

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -2,4 +2,6 @@
 
 body {
 	font-family: "Noto Sans JP", sans-serif;
+	text-align: justify;
+	text-justify: inter-character;
 }


### PR DESCRIPTION
きっとこれから多くのページが日本語で記述されるでしょうから、以下の通り修正を加えました:
- デフォルトの言語を ja-JP に変更します
- ページ全体のテキストを両端揃えで表示します